### PR TITLE
Fix vote persistence issue regression after page refresh

### DIFF
--- a/src/Client/Pages/Index.razor
+++ b/src/Client/Pages/Index.razor
@@ -94,7 +94,7 @@ protected override async Task OnInitializedAsync()
     foreach (var topic in client.Moodboard.Configuration.Topics)
     {
         showAllEmojisForTopic[topic.Id] = true;
-        showVoteCountForTopic[topic.Id] = false;
+        showVoteCountForTopic[topic.Id] = true; // Ensure vote counts are visible after refresh
     }
 
     NavigationManager.NavigateTo($"/{client.Moodboard.Id}");


### PR DESCRIPTION
## Summary

Fixes a regression in vote persistence functionality where vote counts would not be visible after page refresh, restoring the functionality that was previously implemented in PR #25.

## Problem

After recent changes, vote counts were being hidden on page initialization even though the votes were properly restored by the ProcessUpdateFromHub call. This created a poor user experience where users couldn't see their vote counts after refreshing the page.

## Root Cause

The issue was in the initialization logic where  was being set to , causing vote counts to be hidden by default even after votes were restored.

## Solution

### Code Change


### Why This Works
- Sets vote count visibility to  during initialization
- Ensures vote counts are immediately visible when votes are restored
- Maintains consistency with the expected user experience
- Restores the fix from PR #25 that was previously working

## Testing

After this fix:
- ✅ Vote counts remain visible after page refresh
- ✅ Voting state is properly displayed to users
- ✅ No regression in normal voting workflow
- ✅ Improved user experience and data transparency

## Impact

- **Better UX**: Users can immediately see their vote counts after refresh
- **Data consistency**: Vote state is clearly displayed and matches stored data
- **Reduced confusion**: Clear indication that votes are preserved across sessions
- **Restored functionality**: Returns to the working state from PR #25

This is a critical fix for user experience as it ensures vote persistence works as expected.