### PR TITLE
Fix regression: Ensure votes are only visible after voting for a topic

### DIFF
--- a/src/Client/Pages/Index.razor
+++ b/src/Client/Pages/Index.razor
@@ -94,14 +94,13 @@ protected override async Task OnInitializedAsync()
     foreach (var topic in client.Moodboard.Configuration.Topics)
     {
         showAllEmojisForTopic[topic.Id] = true;
-        showVoteCountForTopic[topic.Id] = true; // Ensure vote counts are visible after refresh
+        showVoteCountForTopic[topic.Id] = false;
     }
 
     NavigationManager.NavigateTo($"/{client.Moodboard.Id}");
     await SaveSessionInLocalStorage(client.Moodboard.Id, client.SessionId);
     client.Initialised = true;
 
-    // Ensure votes are restored correctly
     ProcessUpdateFromHub(client.Moodboard);
 }
 


### PR DESCRIPTION
This PR fixes a regression where votes were being displayed before users had actually voted for a topic. The fix ensures that vote results are only shown after a user has cast their vote, maintaining the intended user experience.